### PR TITLE
fix(decisionFull): add missing location field

### DIFF
--- a/jurisprudence/schema.py
+++ b/jurisprudence/schema.py
@@ -137,6 +137,7 @@ class DecisionFull(BaseModel):
     numbers: list[str] = Field(
         description="Tous les numéros de pourvoi de la décision."
     )
+    location: str | None = Field(None, description="Siège ayant rendu la décision.")
     formation: str | None = Field(None, description="Clé de la formation.")
     type: str | None = Field(None, description="Clé du type de décision.")
     decision_date: datetime.date = Field(description="Date de création de la décision.")
@@ -363,6 +364,7 @@ PARQUET_SCHEMA = pa.schema(
         pa.field("decision_date", pa.string()),
         pa.field("themes", pa.list_(pa.string())),
         pa.field("number", pa.string()),
+        pa.field("location", pa.string()),
         pa.field("solution", pa.string()),
         pa.field("ecli", pa.string()),
         pa.field("chamber", pa.string()),


### PR DESCRIPTION
Adding the `location` field to `DecisionFull` object. This field is missing, though it is given by Judilibre API.

Example of the Judilibre API output:
```
https://api.piste.gouv.fr/cassation/judilibre/v1.0/decision?id=5fde3c0fa7f24c18ebc4df29

{
  'id': '5fde3c0fa7f24c18ebc4df29',
  'source': 'jurica',
  'text': 'COUR D\'APPEL\n\n DE \n\nVERSAILLES\n\n\n\n\n\nCode nac : 56C\n\n\n\n13e chambre\n\n\n\nARRET N°\n\n\n\nCONTRADICTOIRE\n\n\n\nDU 03 JUILLET 2018\n\n\n\nN° RG 16/08931\n\n\n\nAFFAIRE :\n\n\n\nSAS SAMFISOL venant aux droits de la SARL VOLTAFRANCE 45\n\n\n\nC/\n\n\n\nSA ENEDIS anciennement dénommée ERDF\n\n\n\n\n\n\n\nDécision déférée à la cour: Jugement rendu le 01 Décembre 2016 par le Tribunal de Commerce de NANTERRE\n\nN° chambre : 3\n\nN° Section : \n\nN° RG : 2014F00751\n\n\n\nExpéditions exécutoires\n\nExpéditions\n\nCopies\n\ndélivrées le : 03.07.18\n\n\n\nà : \n\n\n\nMe Véronique E...,\n\n\n\nMe Bertrand X...,\n\n\n\nTC NANTERRE,\n\n\n\nM.P\n\n\n\nREPUBLIQUE FRANCAISE\n\n\n\nAU NOM DU PEUPLE FRANCAIS\n\n\n\nLE TROIS JUILLET DEUX MILLE DIX HUIT,\n\nLa cour d\'appel de Versailles, a rendu l\'arrêt suivant dans l\'affaire entre: \n\n\n\nSAS SAMFISOL venant aux droits de la SARL VOLTAFRANCE 45\n\n[...]\n\n\n\nReprésenté(e) par Maître Véronique E... de la Y..., avocat postulant au barreau de VERSAILLES, vestiaire : 462 - N° du dossier 39316 et par Maître F. Z..., avocat plaidant au barreau de BEZIER\n\n\n\n\n\nAPPELANTE\n\n****************\n\n\n\n\n\nSA ENEDIS anciennement dénommée ERDF\n\nN° SIRET : 444 608 442\n\n[...]\n\n\n\nReprésenté(e) par Maître Bertrand X... F... D...-C... A... AVOCATS, avocat postulant au barreau de VERSAILLES, vestiaire : 617 - N° du dossier 20170004 et par Maître M. B..., avocat plaidant au barreau de PARIS \n\n\n\n\n\nINTIMEE\n\n****************\n\n\n\n\n\nComposition de la cour :\n\n\n\nL\'affaire a été débattue à l\'audience publique du 06 Mars 2018, Madame Sophie G..., présidente ayant été entendue en son rapport, devant la cour composée de :\n\n\n\nMadame Sophie G..., Présidente,\n\nMadame Hélène GUILLOU, Conseiller,\n\nMadame Florence DUBOIS-STEVANT, Conseiller,\n\n\n\nqui en ont délibéré,\n\n\n\nGreffier, lors des débats : Monsieur Jean-François MONASSIER\n\n\n\nL\'avis du Ministère Public, représenté par Monsieur Fabien BONAN, Avocat Général a été transmis le 10 janvier 2018 au greffe par la voie électronique \n\n\n\nLa société Voltafrance 45 a pour activité la production d\'électricité d\'origine renouvelable. \n\n\n\nElleappartient au groupe SAMFI, lui-même spécialisé dans la production d\'énergie, qui a entrepris de développer de très nombreux projets de centrales d\'électricité photovoltaïque en France et outre-mer au travers de filiales spécialisées par projet sous les dénominations Elecsol, Voltafrance et Batisolaire.\n\n\n\nAfin de favoriser le développement des énergies renouvelables en France, la loi du 10 février 2000 a organisé les modalités de conclusion des contrats d\'achat de l\'électricité ainsi produite entre la société Electricité de France (ci-après EDF) et les producteurs de celle-ci. \n\n\n\nCette loi a notamment donné lieu aux décrets d\'application du 6 décembre 2000 et du 10 mai 2001 et aux arrêtés des 10 juillet 2006 et 12 janvier 2010 qui fixent les prix d\'achat.\n\n\n\nIl est ainsi fait obligation à la société EDF de conclure avec les producteurs intéressés un contrat pour l\'achat de l\'électricité produite par les installations de production d\'électricité qui utilisent des énergies renouvelables à un prix supérieur au prix auquel la société EDF vend son énergie aux consommateurs. \n\n\n\nLe raccordement de ces installations au réseau de distribution est réalisé par la société Électricité Réseau de France, devenue Enedis (ci-après \'la société Enedis\').\n\n\n\nDans le cadre de cette réglementation, la société Voltafrance 45 a décidé de l\'implantation d\'une centrale photovoltaïque d\'une puissance de 90 kWc, sur la commune de Bayeux . Son projet étant soumis à proposition technique et financière de raccordement au réseau (ci-après \'PTF\'), le délai d\'instruction de la demande de raccordement était de trois mois à compter de la date de réception de la demande complète.\n\n\n\nElle a ainsi envoyé par l\'intermédiaire de son mandataire, la société Forclum, une demande de raccordement datée du 27 août 2010. La société Enedis en a accusé réception le 13 octobre 2010 et a informé la société Forclum de la nécessité de réaliser une étude technique détaillée sur place. \n\n\n\nLe décret du 9 décembre 2010 entré en vigueur le 10 décembre 2010 a suspendu pour une durée de trois mois à compter de son entrée en vigueur l\'obligation de conclure un contrat d\'achat de l\'électricité produite par certaines installations photovoltaïques, aucune demande de contrat d\'achat ne pouvant être déposée durant la période de suspension et les demandes suspendues devant faire l\'objet, à l\'issue de la période de suspension, d\'une nouvelle demande complète de raccordement au réseau. Cette suspension ne s\'applique toutefois pas aux installations dont le producteur a notifié au gestionnaire de réseau, avant le 2 décembre 2010, son acceptation de la PTF. A l\'issue de ce moratoire, un arrêté du 4 mars 2011 a fixé le prix d\'achat de cette électricité à des tarifs inférieurs à ceux prévus par les arrêtés antérieurs et exclu du bénéfice de l\'obligation d\'achat les installations d\'une puissance supérieure à 100 kWc, désormais soumises à une procédure d\'appel d\'offres.\n\n\n\nA la fin de la période de suspension, la société Voltafrance 45 n\'a pas déposé de nouvelle demande de raccordement. \n\n\n\nSoutenant que la société Enedis avait commis des fautes, la société Voltafrance 45 puis la société Samfisol venant aux droits de la société Voltafrance 45 l\'ont fait assigner devant le tribunal de commerce de Nanterre en réparation de son préjudice. \n\n\n\nPar jugement contradictoire du 1er décembre 2016, le tribunal de commerce de Nanterre a : \n\n\n\n- joint les causes ; \n\n- débouté la société Samfisol, venant aux droits de la société Voltafrance 45 de toutes ses demandes ; \n\n- dit qu\'il n\'y a lieu à statuer sur la demande de sursis à statuer de la société Enedis ; \n\n- condamné la société Samfisol à payer à la société Enedis, la somme de 5 000 euros au titre de l\'article 700 du code de procédure civile ; \n\n- condamné la société Samfisol aux dépens. \n\n\n\nPar déclaration reçue le 15 décembre 2016, la société Samfisol, venant aux droits de la société Voltafrance 45, a interjeté appel de cette décision. \n\n\n\nDans ses dernières conclusions déposées au greffe et notifiées par RPVA le 30 novembre 2017, la société Samfisol venant aux droits de la société Voltafrance 45 demande à la cour : \n\n\n\n- jugeant que le propre de la responsabilité civile est de replacer la victime dans la situation qui aurait été la sienne si la faute n\'avait pas été commise et, par voie de conséquence, en l\'absence d\'annulation des contrats en cours, que la concluante aurait obtenu un contrat d\'achat insusceptible d\'être remis en cause ;\n\n- jugeant que par sa validation législative du 12 juillet 2010, l\'arrêté du 12 janvier 2010 n\'a plus le caractère réglementaire ;\n\n- jugeant l\'impossibilité pour le tribunal de commerce puis la cour de remettre en cause une disposition législative ;\n\n- jugeant l\'absence de démonstration de la réunion des trois critères de l\'aide d\'Etat exclus par la CJUE au visa de l\'article 9 du code de procédure civile ;\n\n- constatant que Enedis comme ses assureurs n\'invoquent pas que les contrats en cours soient annulables ;\n\n- jugeant que même une illégalité de l\'arrêté ne peut avoir pour effet de remettre les contrats conclus en cause et que le contrat d\'achat aurait nécessairement été conclu en 2011 sans difficulté puisque l\'arrêté du 12 janvier 2010 ne fait l\'objet d\'aucun recours et qu\'il est définitif ;\n\n- jugeant que même dans l\'hypothèse d\'une invalidation de l\'arrêté du 12 janvier 2010, celle-ci ne peut être rétroactive au vu de la jurisprudence de la CJUE et du nombre de contrats impactés; \n\n- en tout état de cause, jugeant la conformité avec le droit européen de l\'aide d\'Etat apportée aux énergies renouvelables et au secteur photovoltaïque en particulier excluant que l\'arrêté du 12 janvier 2010 puisse être invalidé, même s\'il devait être considéré comme une aide d\'Etat et avait organisé la CSPE ;\n\n- constatant que la demande ne consiste pas à obtenir un contrat d\'achat en application de l\'arrêté du 12 janvier 2010 ;\n\n- constatant que si l\'arrêté du 12 janvier 2010 devait être écarté, l\'arrêté du 10 juillet 2006 s\'appliquerait avec un tarif de 60,176 cts/kWh en lieu et place des 42 ou 50 cts revendiqués;\n\n- jugeant la faute d\'Enedis consistant en l\'absence de transmission dans le délai réglementaire de trois mois d\'une proposition technique et financière et en la violation de l\'obligation d\'instruction des dossiers de manière non-discriminatoire ;\n\n\n\n\n\n- jugeant l\'existence du lien de causalité aussi bien sur la causalité adéquate que sur l\'équivalence des conditions ;\n\n- constatant l\'absence d\'une quelconque pièce venant démontrer l\'augmentation prétendue par la seule Enedis des demandes de raccordements durant la dernière semaine d\'août 2010 ;\n\n- rappelant que nul ne peut se constituer de preuve à soi-même et qu\'il appartenait donc à Enedis de produire la file d\'attente des dossiers de demande de raccordement ;\n\n- jugeant qu\'Enedis est soumise à une obligation de résultat par l\'absence d\'aléa sur la réalisation de sa prestation ;\n\n- constatant qu\'Enedis n\'a pas même respecté une obligation de moyens en embauchant uniquement 18 intérimaires à l\'automne 2010 alors que la période était prétendument critique;\n\n- constatant la parfaite connaissance par Enedis du problème des retards dans le traitement des demandes de raccordement excluant toute imprévisibilité et toute extériorité, et par voie de conséquence toute force majeure ;\n\n- constatant la baisse très importante des demandes de raccordement en soutirage et l\'application de la même documentation technique aux demandes de raccordement en injection, excluant toute irrésistibilité, et par voie de conséquence toute force majeure ;\n\n- constatant l\'aveu d\'Enedis devant l\'Autorité de la concurrence de ne pas avoir traité les dossiers dans l\'ordre chronologique, fait constitutif de discrimination ;\n\n- rejeter toute conséquence du défaut de notification de l\'arrêté du 12 janvier 2010 ;\n\n- rejeter l\'argument de l\'illégitimité et de l\'illicéité de la demande ;\n\n- confirmer le jugement en ce qu\'il a rejeté la nullité de l\'assignation délivrée par Samfisol;\n\n- confirmer le jugement en ce qu\'il a retenu la complétude du dossier et la faute commise par Enedis ;\n\n- constatant la pérennité du tarif d\'achat et la fiabilité de la technologie photovoltaïque ;\n\n- constatant la fiabilité des prévisions de production d\'énergie par la transmission de pièces afférentes à plusieurs dizaines de centrales en fonctionnement ;\n\n- jugeant que la jurisprudence indemnise dans une telle hypothèse (contrat d\'achat obligatoire à un tarif connu pour une durée déterminée) la perte de marge sur le contrat perdu ;\n\n- constatant que même l\'application de la théorie de la perte de chance aboutit à l\'indemnisation de près de 100% de la perte de marge ;\n\n- infirmer le jugement en ce qu\'il a exclu la responsabilité de la société Enedis et débouté la concluante de sa demande indemnitaire ;\n\n- par voie de conséquence, condamner la société Enedis à payer à la société Voltafrance 45 une indemnité sur la base de la somme de 551 284 euros outre intérêts au taux légal à compter de l\'assignation ;\n\n- à titre subsidiaire, si la méthode de la VAN devait être retenue, condamner la société Enedis à payer à la société Voltafrance 45 une indemnité sur la base de la somme de 594 023 euros ;\n\n- jugeant qu\'en tout état de cause, si l\'arrêté du 12 janvier 2010 ne pouvait servir de base au calcul de l\'indemnisation, la cour peut valablement l\'évaluer à titre forfaitaire et non plus consécutivement au calcul lié à l\'arrêté, à la somme de 551 284 euros et condamner la société Enedis sur la base de ce montant ;\n\n- condamner en outre la société Enedis au paiement de la somme de 10 000 euros au titre de l\'article 700 du code de procédure civile ainsi qu\'aux entiers dépens, distraits au profit de la Y..., Avocat au Barreau de Versailles.\n\n\n\nDans ses dernières conclusions déposées au greffe et notifiées par RPVA le 12 janvier 2018, la société Enedis demande à la cour de : \n\n\n\n- infirmer le jugement rendu le 1er décembre 2016 par le tribunal de commerce de Nanterre en tant qu\'il l\'a déboutée de son exception de nullité de l\'assignation de la société Samfisol venant aux droits de Voltafrance 45 ;\n\nEn conséquence, \n\n- déclarer nulle l\'assignation de Samfisol ; \n\n- confirmer le jugement rendu le 1er décembre 2016 par le tribunal de commerce de Nanterre en tant qu\'il a débouté Samfisol venant aux droits de Voltafrance 45 de toutes ses demandes; \n\nEn conséquence,\n\n- débouter Samfisol de l\'intégralité de ses demandes indemnitaires ; \n\nEn tout état de cause, \n\n- condamner Samfisol à lui payer la somme de 10 000 euros sur le fondement des dispositions de l\'article 700 du code de procédure civile ; \n\n- condamner Samfisol aux entiers dépens de l\'instance dont le recouvrement sera effectué pour ceux-là concernant par l\'A.A.R.P.I. A... Avocats, représenté par Maître Bertrand X..., et ce conformément aux dispositions de l\'article 699 du code de procédure civile. \n\n\n\nLe ministère public, dans son avis notifié aux parties le 10 janvier 2018, sollicite de la cour qu\'elle tire les conséquences de l\'ordonnance rendue par la Cour de justice de l\'Union européenne le 15 mars 2017 dans l\'affaire C-515/16 et adopte les points de droit suivants \' le mécanisme de l\'obligation d\'achat de l\'électricité produite par les installations utilisant l\'énergie radiative solaire à un prix supérieur à celui du marché et dont le financement est supporté par les consommateurs finals d\'électricité, en application des arrêtés ministériels des 10 juillet 2006 et 12 janvier 2010, doit être considéré comme une intervention de l\'Etat ou au moyen de ressources d\'Etat. En effet, dès lors qu\'il accorde un avantage aux producteurs de cette électricité, cet avantage est susceptible d\'affecter les échanges entre Etats membres et d\'avoir une incidence sur la concurrence ; sont ainsi réunis les critères de l\'aide d\'Etat au sens de l\'article 107 du traité sur le fonctionnement de l\'Union européenne. Les arrêtés susvisés, pris en méconnaissance de l\'obligation de notification préalable à la Commission européenne résultant de l\'article 108 paragraphe 3 du traité sur le fonctionnement de l\'Union européenne, sont entachés d\'illégalité, et, dès lors, ne peuvent être appliqués à la présente affaire\'. Il s\'en rapporte enfin à la sagesse de la cour sur le caractère juridiquement réparable d\'un ou de plusieurs préjudices invoqués par l\'intimée, qui pourrait reposer sur un fondement autre que les arrêtés ministériels susmentionnés.\n\n \n\nL\'ordonnance de clôture a été rendue le 15 janvier 2018. \n\n\n\nPour un plus ample exposé des prétentions et des moyens des parties, il est renvoyé à leurs dernières écritures signifiées conformément aux dispositions de l\'article 455 du code de procédure civile.\n\n\n\nSUR CE,\n\n\n\n1- Sur la nullité de l\'assignation\n\n\n\nEn cause d\'appel, l\'irrecevabilité des demandes de la société Voltafrance 45 n\'est plus discutée.\n\n\n\nLa société Enedis soutient que la société Voltafrance 45 ayant été dissoute puis radiée du registre du commerce et des sociétés de Caen le 12 août 2011, à compter du 23 juillet 2011, elle était dépourvue de personnalité morale et par voie de conséquence du droit d\'agir en justice à la date à laquelle l\'assignation a été délivrée ; que c\'est donc à bon droit que le tribunal a déclaré ses demandes irrecevables ; que s\'agissant d\'une irrégularité pour vice de fond, elle ne pouvait être couverte par la société Samfisol qui ne peut donc pas venir aux droits de la première et reprendre les demandes irrecevables de celle-ci ; qu\'en conséquence, l\'assignation émanant de la société Samfisol doit être déclarée nulle comme venant aux droits d\'une société inexistante ; qu\'enfin la jonction ordonné par le tribunal est critiquable.\n\n\n\nLa société Samfisol expose qu\'afin de mettre un terme à la discussion sur la nullité de l\'assignation initiale, une nouvelle assignation a été délivrée en son nom et qu\'une jonction a été ordonnée par le tribunal ce qui a permis à la procédure d\'être en état et d\'être jugée au fond.\n\n\n\nIl est constant que l\'exploit introductif d\'instance a été délivré le 18 mars 2014 par la SARL Voltafrance 45 alors qu\'il résulte de l\'extrait Kbis du 14 mai 2017 produit que la dissolution de cette société avait été décidée le 14 juin 2011 en suite de la réunion de toutes les parts sociales entre les mains de l\'associé unique, la société Samfisol, et qu\'elle avait ensuite été radiée du registre du commerce et des sociétés de Caen le 12 août 2011 à effet du 23 juillet 2011, en sorte qu\'à cette date elle était dépourvue de droit et de qualité à agir.\n\nLa société Samfisol, qui n\'est pas intervenue dans cette instance pour se substituer à la société radiée ou reprendre les demandes de celle-ci à son compte, a fait délivrer le 6 mai 2015 à la société Enedis une nouvelle assignation en son nom venant aux droits de la société Voltafrance 45 ce que la fusion absorption réalisée lui permettait de faire en raison de la transmission à son profit des droits et obligations de la société Voltafrance 45.\n\n\n\nLa demande tendant à voir déclarer nulle l\'assignation délivrée le 6 mai 2015 sera donc rejetée et le jugement confirmé sur ce point. \n\n\n\n2- Sur les fautes\n\n\n\nLa société Samfisol, venant aux droits de la société Voltafrance 45, soutient pour l\'essentiel que sa demande de raccordement déposée le 27 août 2010 n\'a pas été instruite dans les délais et que la société Enedis, qui ne rapporte pas la preuve que le dossier était incomplet, ne lui a pas transmis de PTF dans le délai de trois mois comme elle y était obligée.\n\nElle prétend également que la société Enedis a violé son obligation légale d\'instruire les dossiers sans discrimination, que dans un audit réalisé par elle-même la société Enedis reconnaît que le traitement des demandes a répondu à d\'autres règles que leur date d\'enregistrement, que ces éléments ont conduit l\'Autorité de la concurrence à poursuivre son enquête sur les pratiques de la société Enedis, qu\'alors que sa propre demande n\'a pas été instruite dans les trois mois une autre société a obtenu une PTF en moins de cinq semaines et qu\'ainsi le principe de sa demande est justifié sur ce seul fondement.\n\n\n\nLa société Enedis réplique que la demande de raccordement était incomplète en ce qu\'elle nécessitait la réalisation d\'une étude technique détaillée sur place, qu\'aucune suite n\'a été donnée à sa demande de rendez-vous, que la demande de raccordement n\'a pas été qualifiée et n\'a donc pas fait courir le délai de trois mois. \n\nElle réfute également tout traitement discriminatoire des demandes de raccordement répliquant que la décision du 4 février 2013 de l\'Autorité de la concurrence ne permet pas d\'en tirer des conclusions ; que l\'Autorité de la concurrence n\'a ni statué de manière définitive, ni reconnu la culpabilité de la société Enedis et que les deux dossiers invoqués par la société Voltafrance 45 ont été régularisés et soumis au moratoire.\n\n\n\n* Sur le non respect du délai\n\n\n\nIl résulte de la délibération de la commission de régulation de l\'énergie du 11 juin 2009 portant décision sur les règles d\'élaboration des procédures de traitement des demandes de raccordement au réseau public de distribution d\'électricité et le suivi de leur mise en oeuvre et de son annexe 1 que la société ERDF, devenue Enedis, avait l\'obligation de transmettre aux demandeurs une PTF dans un délai n\'excédant pas trois mois à compter de la réception de sa demande de raccordement complète.\n\n\n\nL\'article 7.2.3 de la procédure de traitement des demandes de raccordement individuel d\'Enedis applicable à compter du 3 juillet 2010 (ERDF-PRO-RAC-14E Version V.1) pour les installations d\'une puissance supérieure à 36 kVA, prévoit que \' A l\'issue de cet examen et lorsque le dossier est complet, la demande de raccordement est qualifiée. La date de qualification de la demande de raccordement est fixée à la date de réception du dossier lorsque celui-ci est complet ou à la date de réception de la dernière pièce manquante. ERDF confirme par courrier postal ou électronique au demandeur que son dossier est complet. A cette occasion, ERDF communique également la date de qualification de sa demande de raccordement...ainsi que le délai d\'envoi de l\'offre de raccordement\'.\n\nL\'article 8.2.1 de ce document précise qu\'à "compter de la date de qualification de la demande de raccordement, le délai de transmission au demandeur de l\'offre de raccordement ....n\'excédera pas trois mois quel que soit le domaine de tension de raccordement".\n\n\n\nAinsi, sur le fondement des dispositions de l\'article 1382, devenu 1240, du code civil, la société Enedis commet une faute délictuelle lorsque le délai de trois mois dont elle dispose pour adresser une PTF à un candidat au raccordement au réseau électrique n\'est pas respecté.\n\n\n\nCe délai maximum de trois mois se calcule à partir de la date de la réception par la société Enedis du dossier complet de demande de raccordement et s\'apprécie à la date de réception de la PTF par le demandeur. \n\n\n\nEn l\'espèce, il est justifié que la société Voltafrance 45 a, par l\'intermédiaire de la société Forclum, adressé à la société Enedis des \'fiches de collecte de renseignements pour une pré-étude et pour une offre de raccordement au réseau public de distribution géré par ERDF, d\'une installation de production photovoltaïque de puissance supérieure à 36 kVA\', datées du 27 août 2010, comportant habilitation de la société Forclum pour assurer tout ou partie du suivi de la demande de raccordement.\n\n\n\nContrairement à ce qui est vainement soutenu par l\'appelante le dossier n\'a pas été déclaré complet au 27 août 2010.\n\n\n\nEn effet, il est justifié par la production d\'une lettre datée du 13 octobre 2010, ayant pour objet \'rendez-vous pour étude de devis sur site\', adressée à la société Forclum Basse Normandie, soit au nom et à l\'adresse du mandataire désigné sur la fiche, que la société Enedis a bien informé cette dernière de la réception de la demande d\'étude de raccordement pour le projet de centrale situé [...] mais que \'Les éléments fournis nous conduisent à réaliser une étude technique détaillée sur place. A cet effet, un de nos agents ou prestataires se présentera à cette adresse le 29/10/2010. Votre présence ou celle de votre représentant étant indispensable...".\n\n\n\nLa société Enedis affirme qu\'aucune suite n\'a été donnée à cette demande de rendez-vous alors que la société Voltafrance 45 indique qu\'il n\'est pas justifié que la visite n\'a pas pu avoir lieu. Outre la difficulté de rapporter une preuve négative, la société Voltafrance 45 ne démontre ni avoir répondu à cette demande de rendez-vous ou avoir été présente lors de celui-ci ni que cette étude technique ait eu lieu.\n\n\n\nElle ne démontre pas plus que sa demande ait été déclarée complète par la suite. \n\n\n\nDans ces conditions, le délai de trois mois d\'envoi de l\'offre de raccordement n\'a jamais commencé à courir et aucune faute ne peut être reprochée à la société Enedis.\n\n\n\nLe délai n\'ayant pas couru, par suite, aucun reproche lié à un traitement discriminatoire ne peut être formulé à l\'encontre de la société Enedis.\n\n\n\nIl convient, en conséquence, de confirmer le jugement sans qu\'il soit besoin d\'examiner les autres moyens.\n\n\n\n\n\nPAR CES MOTIFS, \n\nLa cour statuant contradictoirement,\n\n\n\nConfirme le jugement ;\n\n\n\nCondamne la SAS Samfisol, venant aux droits de la SARL Voltafrance 45, à payer à la SA Enedis la somme de 5 000 € sur le fondement de l\'article 700 du code de procédure civile ;\n\n\n\nCondamne la SAS Samfisol, venant aux droits de la SARL Voltafrance 45, aux dépens d\'appel avec droit de recouvrement au profit de l\'AARPI A... Avocats, représentée par Me X..., pour les frais dont elle aurait fait l\'avance, conformément à l\'article 699 du code de procédure civile. \n\n\n\nPrononcé publiquement par mise à disposition de l\'arrêt au greffe de la cour, les parties en ayant été préalablement avisées dans les conditions prévues au deuxième alinéa de l\'article 450 du code de procédure civile.\n\n\n\nSigné par Madame Sophie G..., Présidente et par Monsieur MONASSIER, greffier, auquel la minute de la décision a été remise par le magistrat signataire.\n\n\n\n\n\nLe greffier,La présidente,',
  'chamber': '13e chambre',
  'decision_date': '2018-07-03',
  'jurisdiction': 'ca',
  'number': '16/08931',
  'numbers': [
    '16/08931'
  ],
  'publication': [],
  'solution': 'other',
  'solution_alt': "Confirme la décision déférée dans toutes ses dispositions, à l'égard de toutes les parties au recours",
  'type': 'arret',
  'location': 'ca_versailles',
  'update_date': '2021-11-15',
  'nac': 'null',
  'portalis': None,
  'files': [],
  'zones': {
    'introduction': [
      {
        'start': 0,
        'end': 5989
      }
    ],
    'moyens': [
      {
        'start': 5989,
        'end': 14766
      }
    ],
    'motivations': [
      {
        'start': 14766,
        'end': 23224
      }
    ],
    'dispositif': [
      {
        'start': 23224,
        'end': 24180
      }
    ]
  },
  'contested': None,
  'forward': {
    'date': '2020-11-04',
    'title': 'Cour de cassation\nChambre commerciale financière et économique',
    'jurisdiction': 'Cour de cassation',
    'chamber': 'Chambre commerciale financière et économique',
    'solution': 'Rejet',
    'id': '5fca2b949720f107bdacba2e',
    'number': '18-22.227 (et 13 autres)',
    'url': '5fca2b949720f107bdacba2e'
  },
  'timeline': [
    {
      'date': '2018-07-03',
      'title': "Cour d'appel de Versailles\n13",
      'jurisdiction': "Cour d'appel de Versailles",
      'chamber': '13',
      'solution': "Confirme la décision déférée dans toutes ses dispositions, à l'égard de toutes les parties au recours",
      'id': '5fde3c0fa7f24c18ebc4df29',
      'number': '16/08931 (et 6 autres)',
      'url': '5fde3c0fa7f24c18ebc4df29'
    },
    {
      'date': '2018-07-04',
      'title': "Cour d'appel de Versailles\n13",
      'jurisdiction': "Cour d'appel de Versailles",
      'chamber': '13',
      'solution': "Confirme la décision déférée dans toutes ses dispositions, à l'égard de toutes les parties au recours",
      'id': '5fde2831b804ec05d6c8809b',
      'number': '16/08898 (et 5 autres)',
      'url': '5fde2831b804ec05d6c8809b'
    },
    {
      'date': '2018-07-05',
      'title': "Cour d'appel de Versailles\n13",
      'jurisdiction': "Cour d'appel de Versailles",
      'chamber': '13',
      'solution': "Confirme la décision déférée dans toutes ses dispositions, à l'égard de toutes les parties au recours",
      'id': '5fde0e778ab3a2ad6181ef7d',
      'number': '16/07979',
      'url': '5fde0e778ab3a2ad6181ef7d'
    },
    {
      'date': '2020-11-04',
      'title': 'Cour de cassation\nChambre commerciale financière et économique',
      'jurisdiction': 'Cour de cassation',
      'chamber': 'Chambre commerciale financière et économique',
      'solution': 'Rejet',
      'id': '5fca2b949720f107bdacba2e',
      'number': '18-22.227 (et 13 autres)',
      'url': '5fca2b949720f107bdacba2e'
    }
  ],
  'partial': False,
  'visa': [],
  'rapprochements': [],
  'legacy': {},
  'titlesAndSummaries': [],
  'particularInterest': False
}
```